### PR TITLE
feat(ui): build app header and navigation layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"dependencies": {
 		"@hookform/resolvers": "^5.2.2",
 		"@radix-ui/react-label": "^2.1.8",
+		"@radix-ui/react-separator": "^1.1.8",
 		"@radix-ui/react-slot": "^1.2.4",
 		"@tailwindcss/vite": "^4.1.18",
 		"class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.8)(react@19.2.3)
@@ -446,6 +449,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.8':
+    resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2221,6 +2237,15 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.8)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.8
+      '@types/react-dom': 19.2.3(@types/react@19.2.8)
+
+  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,0 +1,28 @@
+import { Home, Pizza, UtensilsCrossed } from "lucide-react";
+
+import { Separator } from "@/components/ui/separator";
+
+import { NavLink } from "./nav-link";
+
+export function Header() {
+  return (
+    <div className="border-b">
+      <div className="flex h-16 items-center gap-6 px-6">
+        <Pizza className="h-6 w-6" />
+
+        <Separator orientation="vertical" className="h-6" />
+
+        <nav className="flex items-center space-x-4 lg:space-x-6">
+          <NavLink to="/">
+            <Home className="h-4 w-4" />
+            Inicio
+          </NavLink>
+          <NavLink to="/orders">
+            <UtensilsCrossed className="h-4 w-4" />
+            Pedidos
+          </NavLink>
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nav-link.tsx
+++ b/src/components/nav-link.tsx
@@ -1,0 +1,15 @@
+import { Link, type LinkProps, useLocation } from "react-router";
+
+type NavLinkProps = LinkProps;
+
+export function NavLink(props: NavLinkProps) {
+  const { pathname } = useLocation();
+
+  return (
+    <Link
+      data-active={pathname === props.to}
+      className="text-muted-foreground hover:text-foreground data-[active=true]:text-foreground data-[active=true]:hover:text-foreground flex items-center gap-1.5 text-sm font-medium transition-colors duration-150"
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/src/pages/_layouts/app.tsx
+++ b/src/pages/_layouts/app.tsx
@@ -1,11 +1,13 @@
 import { Outlet } from "react-router";
 
+import { Header } from "@/components/header";
+
 export function AppLayout() {
   return (
-    <div>
-      <h1>Cabeçalho</h1>
+    <div className="flex min-h-screen flex-col antialiased">
+      <Header />
 
-      <div>
+      <div className="flex flex-1 flex-col gap-4 p-8 pt-6">
         <Outlet />
       </div>
 

--- a/src/pages/_layouts/auth.tsx
+++ b/src/pages/_layouts/auth.tsx
@@ -3,7 +3,7 @@ import { Outlet } from "react-router";
 
 export function AuthLayout() {
   return (
-    <div className="grid min-h-screen grid-cols-2">
+    <div className="grid min-h-screen grid-cols-2 antialiased">
       <div className="border-foreground/5 bg-muted text-muted-foreground flex h-full flex-col justify-between border-r p-10">
         <div className="text-foreground flex items-center gap-3 text-lg font-medium">
           <Pizza className="h-5 w-5" />{" "}


### PR DESCRIPTION
## 🎨 Layout Base e Navegação (Header)

### 📝 Descrição
Implementação do layout principal da aplicação (App Shell), contendo o cabeçalho fixo com o menu de navegação e o suporte para rotas aninhadas via `Outlet`.

### 💡 Por que foi feito dessa forma? (Decisões Técnicas)
1. **Estado Ativo via Data Attribute**: Em vez de classes condicionais complexas no JavaScript, utilizei o atributo data-active={pathname === props.to}. Isso permite estilizar o link ativo diretamente no Tailwind usando o seletor data-[active=true]:text-foreground, deixando o JSX mais limpo.
2. **Tipagem Estrita (LinkProps)**: Para o componente NavLink, aproveitei a tipagem nativa do React Router. Ao fazer type NavLinkProps = LinkProps, garantimos que nosso componente aceite todas as propriedades padrão de um link (como to, replace, etc) sem precisar redeclarar tipos manualmente.
3. **Layout Persistente**: O uso de um componente pai com <Outlet /> garante que o Header não seja recarregado a cada troca de rota.

### ⚙️ Detalhes da Implementação
* **Componente NavLink**: Wrapper em volta do Link do React Router para encapsular a lógica visual de "ativo/inativo".
* **Shadcn UI**: Utilização do componente Separator da biblioteca shadcn/ui para criar a divisão vertical visual entre o logo e o menu.
* **Dependência**: react-router-dom (Hook useLocation para verificar a rota ativa).
* **Ícones**: Utilização do lucide-react (ícone Pizza).

### 🧪 Como Testar
1. Baixe a branch e instale as dependências.
2. Execute o projeto (`pnpm dev` ou `npm run dev`).
3. Observe o cabeçalho fixo no topo da página.
4. Clique nos itens do menu (ex: Dashboard, Pedidos).
5. **Verifique:**
* A URL muda corretamente.
* O item clicado muda de cor (destaque de ativo).
* O conteúdo principal altera (se houver conteúdo nas rotas), mas o cabeçalho permanece estático.

### 🔨 Checklist
* [x] Criação do componente NavLink com tipagem LinkProps.
* [x] Implementação do Layout principal com Header.
* [x] Lógica de `data-current` para links ativos.
* [x] Integração do componente Separator (shadcn/ui).