### PR TITLE
feat(ui): implement 404 not found page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "sonner";
 import { ThemeProvider } from "@/components/theme/theme-provider";
 import { AppLayout } from "@/pages/_layouts/app";
 import { AuthLayout } from "@/pages/_layouts/auth";
+import { NotFound } from "@/pages/404";
 import { Dashboard } from "@/pages/app/dashboard/dashboard";
 import { Orders } from "@/pages/app/orders/orders";
 import { SignIn } from "@/pages/auth/sign-in";
@@ -19,14 +20,21 @@ export function App() {
           <Helmet titleTemplate="%s | pizza.shop" />
           <BrowserRouter>
             <Routes>
+              {/* Rotas da Aplicação (Dashboard, etc) */}
               <Route path="/" element={<AppLayout />}>
+                <Route path="/" element={<Dashboard />} />
                 <Route path="/dashboard" element={<Dashboard />} />
                 <Route path="/orders" element={<Orders />} />
               </Route>
+
+              {/* Rotas de Autenticação */}
               <Route path="/" element={<AuthLayout />}>
                 <Route path="/sign-in" element={<SignIn />} />
                 <Route path="/sign-up" element={<SignUp />} />
               </Route>
+
+              {/* Rota 404 (Catch-all) */}
+              <Route path="*" element={<NotFound />} />
             </Routes>
           </BrowserRouter>
         </ThemeProvider>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,15 @@
+import { Link } from "react-router";
+
+export function NotFound() {
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-2 px-4 sm:px-6 lg:px-8">
+      <h1 className="text-4xl font-bold">Página não encontrada.</h1>
+      <p className="text-accent-foreground">
+        Voltar para o{" "}
+        <Link to="/" className="text-sky-500 dark:text-sky-400">
+          Dashboard
+        </Link>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🚫 Página 404 (Not Found)

### 📝 Descrição
Implementação da página de erro 404 para lidar com acessos a rotas inexistentes na aplicação.

### 💡 Por que foi feito dessa forma? (Decisões Técnicas)
1. **Rota Catch-All (`path="*"`):** Como estamos utilizando a estrutura de componentes do React Router v7 (`<Routes>`), a maneira padrão de lidar com 404 é adicionar uma rota `*` no final da lista. Isso substitui o uso do `errorElement` na raiz (que é comum na abordagem `createBrowserRouter`) para fins de "rota não encontrada".
2. **Layout Isolado:** A página 404 foi colocada fora dos layouts principais (`AppLayout` e `AuthLayout`) para garantir que ela seja renderizada de forma limpa, centralizada na tela, sem menus ou sidebars quebrados.

### ⚙️ Detalhes da Implementação
* **Arquivo:** `src/pages/404.tsx`.
* **Router:** Adição de `<Route path="*" element={<NotFound />} />` no `App.tsx`.
* **Componente:** Interface simples com título e link de retorno usando classes utilitárias do Tailwind para centralização.

### 🧪 Como Testar
1. Rode a aplicação (`pnpm dev`).
2. Tente acessar uma URL inexistente propositalmente (ex: `http://localhost:5173/batata`).
3. **Verifique:**
   * A página "Página não encontrada" deve aparecer.
   * O link "Dashboard" deve redirecionar corretamente para a home.


### 🔨 Checklist

* [x] Criação do componente `NotFound`.
* [x] Configuração da rota curinga (`*`) no `App.tsx`.