### PR TITLE
feat(auth): integrate sign-in form with backend api

### DIFF
--- a/src/api/sign-in.ts
+++ b/src/api/sign-in.ts
@@ -1,0 +1,9 @@
+import { api } from "@/lib/axios";
+
+export interface SignInBody {
+  email: string;
+}
+
+export async function signIn({ email }: SignInBody) {
+  await api.post("/authenticate", { email });
+}

--- a/src/pages/auth/sign-in.tsx
+++ b/src/pages/auth/sign-in.tsx
@@ -1,9 +1,11 @@
+import { useMutation } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
 import { useForm } from "react-hook-form";
 import { Link } from "react-router";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { signIn } from "@/api/sign-in";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -24,9 +26,22 @@ export function SignIn() {
     formState: { isSubmitting },
   } = useForm<signInFormSchemaType>();
 
+  /**
+   * useMutation: Hook do React Query para operações de escrita (POST/PUT/DELETE).
+   * * - mutationFn: A função que executa a operação assíncrona. Ao passar 'signIn', conectamos
+   * diretamente à chamada da API.
+   *
+   * * - mutateAsync: A função que dispara a mutação. Renomeamos para 'authenticate' para ficar
+   * semântico. Diferente do 'mutate' comum, ela retorna uma Promise, permitindo usar
+   * await e try/catch dentro do handleSignIn.
+   */
+  const { mutateAsync: authenticate } = useMutation({
+    mutationFn: signIn,
+  });
+
   async function handleSignIn(data: signInFormSchemaType) {
     try {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+      await authenticate({ email: data.email });
 
       toast.success("Enviamos um link com autenticação para seu e-mail.", {
         duration: 5000,


### PR DESCRIPTION
## 🔐 Integração da Autenticação (Sign In)

### 📝 Descrição
Implementação da lógica de autenticação no formulário de login. Conectamos o front-end ao back-end através da rota de `authenticate`, utilizando o **React Query** para gerenciar o estado da requisição e o **Axios** para a comunicação HTTP.

### 💡 Por que foi feito dessa forma? (Decisões Técnicas)
1. **React Query (`useMutation`):**
   * Optei pelo `useMutation` em vez de um `axios.post` solto, pois ele nos entrega de graça estados de `isPending` (loading) e tratamento de erros padronizado.
   * Utilizei especificamente o `mutateAsync`. Isso permite usar `await authenticate()` dentro do `handleSignIn`, possibilitando o uso de blocos `try/catch` para disparar os Toasts de sucesso ou erro na hora certa.

2. **Camada de API Isolada:**
   * Criei o arquivo `src/api/sign-in.ts`. Isso desacopla o componente da lógica HTTP. Se a URL ou o método da API mudar, alteramos apenas nesse arquivo, e não dentro do componente React.

3. **Feedback Visual:** Integração com a lib `sonner` para exibir mensagens de sucesso (com botão de reenvio) ou erro de credenciais.

### ⚙️ Detalhes da Implementação
* **Arquivo API:** `src/api/sign-in.ts` (Função tipada recebendo e-mail).
* **Componente:** `sign-in.tsx` atualizado.
* **Hook:** Uso do `useForm` (React Hook Form) em conjunto com a mutação.

### 🧪 Como Testar
1. **Pré-requisito:** O Back-end deve estar rodando (ou o mock do json-server se estivermos simulando).
2. Acesse a página de Login (`/sign-in`).
3. **Cenário Sucesso:**
   * Digite um e-mail válido e clique em "Acessar painel".
   * Verifique se o Toast de sucesso aparece.

4. **Cenário Erro:**
   * Simule um erro (ou desligue o backend) e tente logar.
   * Verifique se o Toast de "Credenciais inválidas" aparece.

### 🔨 Checklist
* [x] Criação da função de API `signIn`.
* [x] Implementação do `useMutation` no componente.
* [x] Tratamento de erros com `try/catch`.
* [x] Feedback visual via Toast.