### PR TITLE
feat(auth): implement restaurant registration and ux flow

### DIFF
--- a/src/api/register-restaurant.ts
+++ b/src/api/register-restaurant.ts
@@ -1,0 +1,22 @@
+import { api } from "@/lib/axios";
+
+export interface RegisterRestaurantBody {
+  restaurantName: string;
+  managerName: string;
+  phone: string;
+  email: string;
+}
+
+export async function registerRestaurant({
+  restaurantName,
+  managerName,
+  phone,
+  email,
+}: RegisterRestaurantBody) {
+  await api.post("/restaurants", {
+    restaurantName,
+    managerName,
+    phone,
+    email,
+  });
+}

--- a/src/pages/auth/sign-in.tsx
+++ b/src/pages/auth/sign-in.tsx
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
 import { useForm } from "react-hook-form";
-import { Link } from "react-router";
+import { Link, useSearchParams } from "react-router";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -20,11 +20,21 @@ const signInFormSchema = z.object({
 type signInFormSchemaType = z.infer<typeof signInFormSchema>;
 
 export function SignIn() {
+  const [searchParams] = useSearchParams();
+
+  /**
+   * defaultValues: Captura o e-mail da URL (caso o usuário tenha sido redirecionado após o cadastro)
+   * e pré-preenche o campo de e-mail no formulário de login.
+   */
   const {
     register,
     handleSubmit,
     formState: { isSubmitting },
-  } = useForm<signInFormSchemaType>();
+  } = useForm<signInFormSchemaType>({
+    defaultValues: {
+      email: searchParams.get("email") ?? "",
+    },
+  });
 
   /**
    * useMutation: Hook do React Query para operações de escrita (POST/PUT/DELETE).

--- a/src/pages/auth/sign-up.tsx
+++ b/src/pages/auth/sign-up.tsx
@@ -1,9 +1,11 @@
+import { useMutation } from "@tanstack/react-query";
 import { Helmet } from "react-helmet-async";
 import { useForm } from "react-hook-form";
 import { Link, useNavigate } from "react-router";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import { registerRestaurant } from "@/api/register-restaurant";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -28,17 +30,28 @@ export function SignUp() {
     formState: { isSubmitting },
   } = useForm<signUpFormSchemaType>();
 
+  const { mutateAsync: registerRestaurantFn } = useMutation({
+    mutationFn: registerRestaurant,
+  });
+
   async function handleSignUp(data: signUpFormSchemaType) {
     try {
-      console.log(data);
+      await registerRestaurantFn({
+        restaurantName: data.restaurantName,
+        managerName: data.managerName,
+        phone: data.phone,
+        email: data.email,
+      });
 
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-
+      /**
+       * Toast com ação personalizada para redirecionar o usuário para a tela de login
+       * após o cadastro do restaurante, já com o e-mail preenchido no formulário de login.
+       */
       toast.success("Restaurante cadastrado com sucesso.", {
         duration: 5000,
         action: {
           label: "Login",
-          onClick: () => navigate("/sign-in"),
+          onClick: () => navigate(`/sign-in?email=${data.email}`),
         },
       });
     } catch (error) {


### PR DESCRIPTION
## 👨🏻‍🍳 Cadastro de Restaurante e Fluxo de UX

### 📝 Descrição

Implementação da tela de cadastro de novos estabelecimentos (`SignUp`). Além da criação do formulário e integração com a API, foi implementado um fluxo de UX onde, após o sucesso, o usuário é redirecionado para o login com o e-mail já preenchido.

### 💡 Por que foi feito dessa forma? (Decisões Técnicas)

1. **Reaproveitamento de Padrões:** A estrutura do formulário segue o mesmo padrão do Login (Zod + React Hook Form + Shadcn UI), garantindo consistência visual e de código.
2. **Fluxo de Redirecionamento (URL Search Params):**
   * No **Cadastro**: Ao finalizar com sucesso, o Toast oferece um botão de ação que leva para `/sign-in?email=usuario@exemplo.com`.
   * No **Login**: Adicionei a leitura de `searchParams` no `defaultValues` do formulário. Isso remove o atrito do usuário ter que digitar o e-mail novamente logo após ter acabado de se cadastrar.


3. **Abstração da API:** Assim como no login, a lógica do `axios.post` foi isolada no arquivo `api/register-restaurant.ts`.

### ⚙️ Detalhes da Implementação
* **Arquivos Criados/Alterados:**
   * `src/api/register-restaurant.ts`: Função de cadastro.
   * `src/pages/auth/sign-up.tsx`: Tela de cadastro com os campos Nome, Gerente, Email e Telefone.
   * `src/pages/auth/sign-in.tsx`: Ajuste para ler o e-mail da URL.

### 🧪 Como Testar
1. Acesse a rota `/sign-up`.
2. Preencha os dados (pode usar dados fictícios).
3. Clique em "Finalizar cadastro".
4. **Verifique:**
   * Se o Toast de sucesso aparece.
   * Clique no botão "Login" dentro do Toast.

5. **Confirmação:**
   * Você deve ser redirecionado para a tela de Login.
   * **O campo de e-mail já deve vir preenchido.**

### 🔨 Checklist
* [x] Criação da função API `registerRestaurant`.
* [x] Criação da tela de `SignUp`.
* [x] Integração do `useMutation` no cadastro.
* [x] Lógica de Query Params para preenchimento automático do e-mail no Login.