### PR TITLE
feat(ui): connect header to user profile and restaurant data

### DIFF
--- a/src/api/get-managed-restaurant.ts
+++ b/src/api/get-managed-restaurant.ts
@@ -1,0 +1,18 @@
+import { api } from "@/lib/axios";
+
+interface GetManagedRestaurantResponse {
+  id: string;
+  name: string;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+  description: string | null;
+  managerId: string | null;
+}
+
+export async function getManagedRestaurant() {
+  const response = await api.get<GetManagedRestaurantResponse>(
+    "/managed-restaurant",
+  );
+
+  return response.data;
+}

--- a/src/api/get-profile.ts
+++ b/src/api/get-profile.ts
@@ -1,0 +1,17 @@
+import { api } from "@/lib/axios";
+
+interface GetProfileResponse {
+  id: string;
+  name: string;
+  email: string;
+  phone: string | null;
+  role: "manager" | "customer";
+  createdAt: Date | null;
+  updatedAt: Date | null;
+}
+
+export async function getProfile() {
+  const response = await api.get<GetProfileResponse>("/me");
+
+  return response.data;
+}

--- a/src/components/account-menu.tsx
+++ b/src/components/account-menu.tsx
@@ -1,4 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
 import { Building, ChevronDown, LogOut } from "lucide-react";
+import { get } from "react-hook-form";
+
+import { getManagedRestaurant } from "@/api/get-managed-restaurant";
+import { getProfile } from "@/api/get-profile";
 
 import { Button } from "./ui/button";
 import {
@@ -11,6 +16,16 @@ import {
 } from "./ui/dropdown-menu";
 
 export function AccountMenu() {
+  const { data: profile } = useQuery({
+    queryKey: ["profile"],
+    queryFn: getProfile,
+  });
+
+  const { data: managedRestaurant } = useQuery({
+    queryKey: ["managed-restaurant"],
+    queryFn: getManagedRestaurant,
+  });
+
   return (
     <DropdownMenu>
       {/* Todas as propriedades e funcionamento de <DropdownMenuTrigger /> serão 
@@ -20,15 +35,15 @@ export function AccountMenu() {
           variant="outline"
           className="flex items-center gap-2 select-none"
         >
-          Pizza Shop
+          {managedRestaurant?.name}
           <ChevronDown className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuLabel className="flex flex-col">
-          <span>Wend</span>
+          <span>{profile?.name}</span>
           <span className="text-muted-foreground text-xs font-normal">
-            @wend
+            {profile?.email}
           </span>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -4,4 +4,5 @@ import { env } from "@/env";
 
 export const api = axios.create({
   baseURL: env.VITE_API_URL,
+  withCredentials: true,
 });


### PR DESCRIPTION
## 👤 Perfil do Usuário e Restaurante no Cabeçalho

### 📝 Descrição

Implementação da lógica de busca de dados do usuário logado e do estabelecimento gerenciado. Agora, o **Cabeçalho (Header)** deixa de exibir dados estáticos ("Pizza Shop") e passa a exibir o nome real do restaurante e do gerente, obtidos via API.

### 💡 Por que foi feito dessa forma? (Decisões Técnicas)
1. **Axios `withCredentials: true`:**
   * Esta é a mudança mais crítica. Habilitei essa opção na instância do Axios (`lib/axios.ts`) para que o navegador envie e receba automaticamente os **Cookies HttpOnly** de autenticação em todas as requisições. Sem isso, o Backend não reconhece quem está logado.

2. **Separação de Requests:**
   * Criei duas funções de API distintas: `getProfile` (dados do usuário) e `getManagedRestaurant` (dados da loja).
   * Utilizei o `useQuery` para ambas. Como são dados que mudam pouco, o cache do React Query evita requisições desnecessárias ao navegar entre páginas.

### ⚙️ Detalhes da Implementação
* **Configuração:** `src/lib/axios.ts` atualizado com credenciais.
* **Novas APIs:**
   * `src/api/get-profile.ts`
   * `src/api/get-managed-restaurant.ts`

* **Componente:** `src/components/header.tsx` conectado aos hooks do React Query.

### 🧪 Como Testar
1. **Pré-requisito:** Faça login na aplicação (o Backend deve setar o cookie de sessão).
2. Observe o **Canto Superior Direito** e o **Lado Esquerdo** do cabeçalho.
3. **Verifique:**
   * Ao invés de "Pizza Shop", deve aparecer o nome do restaurante cadastrado.
   * Ao abrir o menu de perfil, deve aparecer o nome do gerente e o e-mail.

4. **Rede (DevTools):** Verifique na aba Network se as chamadas `/me` e `/managed-restaurant` estão sendo feitas e retornando 200.

### 🔨 Checklist
* [x] Configuração global do Axios (`withCredentials`).
* [x] Criação das funções de fetch de dados.
* [x] Integração do `Header` com `useQuery`.
* [x] Renderização condicional dos dados do perfil.

### 🎓 Dica de Mentor: Cookies vs Headers

- **"Por que `withCredentials`?"**
   - Quando a autenticação é via **Token (JWT) no Header Authorization**, nós precisamos injetar o token manualmente em cada request.
   - Mas, neste projeto, estamos usando **Cookies HttpOnly**. O navegador, por segurança, não envia cookies em requisições de domínios cruzados (CORS) ou fetch API a menos que a gente diga explicitamente "Ei, pode levar as credenciais junto!". É isso que o `withCredentials: true` faz. É mais seguro, pois o JavaScript do front-end não consegue ler o cookie, protegendo contra ataques XSS.