### PR TITLE
feat(ui): implement store profile update mutation and caching

### DIFF
--- a/src/api/register-restaurant.ts
+++ b/src/api/register-restaurant.ts
@@ -1,6 +1,6 @@
 import { api } from "@/lib/axios";
 
-export interface RegisterRestaurantBody {
+interface RegisterRestaurantBody {
   restaurantName: string;
   managerName: string;
   phone: string;

--- a/src/api/sign-in.ts
+++ b/src/api/sign-in.ts
@@ -1,6 +1,6 @@
 import { api } from "@/lib/axios";
 
-export interface SignInBody {
+interface SignInBody {
   email: string;
 }
 

--- a/src/api/update-profile.ts
+++ b/src/api/update-profile.ts
@@ -1,0 +1,13 @@
+import { api } from "@/lib/axios";
+
+interface UpdateProfileBody {
+  name: string;
+  description: string | null;
+}
+
+export async function updateProfile({ name, description }: UpdateProfileBody) {
+  await api.put("/profile", {
+    name,
+    description,
+  });
+}

--- a/src/components/account-menu.tsx
+++ b/src/components/account-menu.tsx
@@ -27,6 +27,15 @@ export function AccountMenu() {
     useQuery({
       queryKey: ["managed-restaurant"],
       queryFn: getManagedRestaurant,
+      /**
+       * staleTime: Define por quanto tempo os dados são considerados "frescos". Durante esse período, o React Query não irá refazer a
+       * requisição para obter os dados novamente, mesmo que o componente seja re-renderizado ou re-montado.
+       * No caso do perfil da loja, as informações não mudam com frequência, então podemos definir um tempo infinito para evitar requisições desnecessárias.
+       *
+       * É necessário adicionar essa flag nos outros componentes que também buscam as informações do restaurante gerenciado,
+       * como o dashboard, para garantir que a informação seja consistente em toda a aplicação e evitar refetch desnecessário.
+       */
+      staleTime: Infinity,
     });
 
   return (


### PR DESCRIPTION
## 🔄 Atualização de Perfil e Otimização de Cache

### 📝 Descrição
Implementação da lógica de envio do formulário de "Perfil da Loja". Agora, ao clicar em "Salvar", os dados são enviados para a API via mutação. Além disso, foi aplicada uma estratégia de cache para reduzir o número de requisições ao servidor.

### 💡 Por que foi feito dessa forma? (Decisões Técnicas)
1. **Mutation (`useMutation`):** Utilizei o hook de mutação para enviar os dados (PUT). Isso permite gerenciar o ciclo de vida da requisição (loading, success, error) e disparar os Toasts de feedback visual para o usuário.
2. **Fechamento do Modal:** Implementei lógica para fechar o modal, que antes não estava fechando ao apertar em `Cancelar`.
3. **Otimização de Cache (`staleTime`):**
   * Percebi que as informações da loja (Nome e Descrição) mudam com pouquíssima frequência. Por padrão, o React Query considera os dados "velhos" (stale) imediatamente e faz novas requisições sempre que o usuário foca na janela (`refetchOnWindowFocus`).
   * **Decisão:** Configurei `staleTime: Infinity`. Isso diz ao React Query: "Uma vez baixado, considere esse dado fresco para sempre (enquanto a tela estiver aberta)". Isso economiza banda e requisições desnecessárias.

### ⚙️ Detalhes da Implementação
* **Nova API:** `src/api/update-profile.ts`.
* **Componente:** `store-profile-dialog.tsx`.
* **Cache:** Adição da flag `staleTime: Infinity` na query `managed-restaurant`.

### ⚠️ Observação / Próximos Passos

- **Atualização da Interface (Cache Invalidation):**
   - Como definimos o `staleTime: Infinity`, no momento atual, a interface **não reflete a mudança imediatamente** após salvar. O nome antigo permanece na tela até que a página seja recarregada manualmente.
   - **Próxima Etapa:** Na sequência, implementaremos a **Invalidação de Query** (`queryClient.invalidateQueries`) no sucesso da mutação. Isso forçará o React Query a buscar os dados atualizados automaticamente, garantindo que a UI esteja sempre sincronizada com o Backend sem precisar de F5.

### 🧪 Como Testar
1. Abra o modal de Perfil da Loja.
2. Altere o nome ou descrição e salve.
3. **Sucesso:** Deve aparecer um Toast verde e o modal deve fechar.
4. **Teste de Cache:**
   * Abra o DevTools (Aba Network).
   * Feche o modal e clique em qualquer outro lugar fora do navegador.
   * Clique de volta no navegador (foco).
   * **Esperado:** Nenhuma nova requisição `/managed-restaurant` deve aparecer no Network (graças ao `staleTime`).

### 🔨 Checklist
* [x] Criação da função de API `updateProfile`.
* [x] Implementação do `useMutation` no formulário.
* [x] Feedback visual (Toasts).
* [x] Configuração de `staleTime: Infinity` para evitar refetchs.

### 🎓 Estratégia de "Stale While Revalidate"

Decidi configurar o `staleTime: Infinity` especificamente para a query do restaurante gerenciado. Como o nome e a descrição da loja são dados estáticos na maior parte do tempo, não faz sentido o React Query buscar essa informação novamente toda vez que o usuário troca de aba ou foca na janela. Com essa configuração, garantimos que a requisição aconteça apenas uma vez (ou quando invalidarmos o cache manualmente), tornando a aplicação mais ágil e econômica.