### PR TITLE
feat(infra): implement optimistic ui and error simulation infra

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -8,6 +8,8 @@ import { z } from "zod";
 const envSchema = z.object({
   VITE_API_URL: z.url(),
   VITE_ENABLE_API_DELAY: z.string().transform((value) => value === "true"),
+  VITE_ENABLE_API_ERROR: z.string().transform((value) => value === "true"),
+  VITE_API_ERROR_TARGET: z.string().optional(),
 });
 
 /**

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -24,3 +24,45 @@ if (env.VITE_ENABLE_API_DELAY) {
     return config;
   });
 }
+
+/**
+ * Interceptor de Erros (Fault Injection)
+ * Permite testar interfaces otimistas e tratamentos de erro.
+ *
+ * Se a variável de ambiente VITE_ENABLE_API_ERROR estiver habilitada, o interceptor irá simular um erro para todas as requisições.
+ *
+ * Caso a variável de ambiente VITE_API_ERROR_TARGET esteja definida, o interceptor irá simular o erro apenas para as
+ * requisições cujo URL contenha o valor definido nessa variável.
+ * O erro é simulado após um delay de 3 segundos para permitir testar os estados de loading e erro da aplicação.
+ *
+ * Exemplo de uso:
+ * - Para simular erro em todas as requisições:
+ *   VITE_ENABLE_API_ERROR=true
+ *
+ * - Para simular erro apenas nas requisições que contenham "profile" na URL:
+ *   VITE_ENABLE_API_ERROR=true
+ *   VITE_API_ERROR_TARGET=profile
+ */
+if (env.VITE_ENABLE_API_ERROR) {
+  api.interceptors.request.use(async (config) => {
+    if (
+      env.VITE_API_ERROR_TARGET &&
+      !config.url?.includes(env.VITE_API_ERROR_TARGET)
+    ) {
+      return config;
+    }
+
+    // Simula um erro no endpoint definido no VITE_API_ERROR_TARGET ou em todas as requisições se o target não for definido.
+    await new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        reject(
+          new Error(
+            `Erro simulado via interceptador de erros (Target: ${env.VITE_API_ERROR_TARGET || "ALL"})`,
+          ),
+        );
+      }, 3000);
+    });
+
+    return config;
+  });
+}


### PR DESCRIPTION
## ⚡ Interface Otimista (Optimistic UI) e Infra de Testes

### 📝 Descrição da PR

Esta PR implementa a estratégia de **Interface Otimista** (Optimistic UI) na atualização do perfil da loja, melhorando a percepção de performance para o usuário.

Além disso, introduz uma infraestrutura de **Injeção de Falhas** (Fault Injection) utilizando **duas novas variáveis de ambiente**, permitindo simular erros de API em rotas específicas sem afetar o restante da aplicação.

### 💡 Alterações no `env` (Infraestrutura)
Foram adicionadas duas novas variáveis ao schema do Zod em `src/env.ts` para controlar os testes de erro:
1. **`VITE_ENABLE_API_ERROR`** (Boolean):
   * Atua como uma chave geral ("Master Switch").
   * Se `true`, habilita o interceptor de erros no Axios.

2. **`VITE_API_ERROR_TARGET`** (String | Optional):
   * Atua como um filtro de escopo.
   * Define qual rota/endpoint deve falhar (ex: `profile`).
   * Se definido, o erro só ocorre se a URL da requisição contiver essa string.

### ⚙️ Detalhes da Implementação
* **Frontend (`StoreProfileDialog`):**
   * Refatoração para usar `onMutate` (atualização imediata do cache).
   * Implementação de lógica de **Rollback** no `onError` (restaura o backup dos dados se a API falhar).
* **Backend Mock (`src/lib/axios.ts`):**
   * Configuração de interceptor que verifica as duas variáveis acima.
   * Simula um delay de 3s seguido de um `reject` apenas na rota alvo.

### 🧪 Como Testar (Simulação de Erro Controlada)
Para validar o **Rollback** (o dado volta ao original após o erro), configure o seu `.env.local` desta forma:

```env
# Liga o delay para vermos o loading (se houver) ou a transição
VITE_ENABLE_API_DELAY=true

# Liga o modo de erro
VITE_ENABLE_API_ERROR=true

# Restringe o erro APENAS para a rota de perfil (outras rotas funcionam normal)
VITE_API_ERROR_TARGET=profile
```

**Passo a passo:**
1. Reinicie o projeto (`pnpm dev`).
2. Acesse o Perfil da Loja.
3. Mude o nome e salve.
4. **Resultado Esperado:**
   * O nome muda na hora (Otimista).
   * Após 3 segundos, aparece o Toast: *"Falha ao atualizar perfil..."*.
   * O nome volta automaticamente para o valor anterior.

### 🔨 Checklist
* [x] Adição de `VITE_ENABLE_API_ERROR` e `VITE_API_ERROR_TARGET` no env schema.
* [x] Interceptor do Axios configurado com filtro de URL.
* [x] Mutação otimista com snapshot e rollback implementada.