### PR TITLE
feat(orders): implement server-side pagination and url sync

### DIFF
--- a/src/api/get-orders.ts
+++ b/src/api/get-orders.ts
@@ -1,5 +1,9 @@
 import { api } from "@/lib/axios";
 
+interface GetOrdersParams {
+  pageIndex?: number | null;
+}
+
 interface GetOrdersResponse {
   orders: {
     orderId: string;
@@ -15,10 +19,10 @@ interface GetOrdersResponse {
   };
 }
 
-export async function getOrders() {
+export async function getOrders({ pageIndex = 0 }: GetOrdersParams) {
   const response = await api.get<GetOrdersResponse>("/orders", {
     params: {
-      pageIndex: 0,
+      pageIndex,
     },
   });
 

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -4,18 +4,21 @@ import {
   ChevronsLeft,
   ChevronsRight,
 } from "lucide-react";
+
 import { Button } from "./ui/button";
 
 interface PaginationProps {
   pageIndex: number;
   perPage: number;
   totalCount: number;
+  onPageChange?: (pageIndex: number) => Promise<void> | void;
 }
 
 export function Pagination({
   pageIndex,
   perPage,
   totalCount,
+  onPageChange,
 }: PaginationProps) {
   const pages = Math.ceil(totalCount / perPage) || 1;
 
@@ -30,19 +33,39 @@ export function Pagination({
           Página {pageIndex + 1} de {pages}
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="outline" className="h-8 w-8 p-0">
+          <Button
+            onClick={() => onPageChange?.(0)}
+            variant="outline"
+            className="h-8 w-8 p-0"
+            disabled={pageIndex === 0}
+          >
             <ChevronsLeft className="h-4 w-4" />
             <span className="sr-only">Primeira página</span>
           </Button>
-          <Button variant="outline" className="h-8 w-8 p-0">
+          <Button
+            onClick={() => onPageChange?.(pageIndex - 1)}
+            variant="outline"
+            className="h-8 w-8 p-0"
+            disabled={pageIndex === 0}
+          >
             <ChevronLeft className="h-4 w-4" />
             <span className="sr-only">Página anterior</span>
           </Button>
-          <Button variant="outline" className="h-8 w-8 p-0">
+          <Button
+            onClick={() => onPageChange?.(pageIndex + 1)}
+            variant="outline"
+            className="h-8 w-8 p-0"
+            disabled={pages <= pageIndex + 1}
+          >
             <ChevronRight className="h-4 w-4" />
             <span className="sr-only">Próxima página</span>
           </Button>
-          <Button variant="outline" className="h-8 w-8 p-0">
+          <Button
+            onClick={() => onPageChange?.(pages - 1)}
+            variant="outline"
+            className="h-8 w-8 p-0"
+            disabled={pages <= pageIndex + 1}
+          >
             <ChevronsRight className="h-4 w-4" />
             <span className="sr-only">Última página</span>
           </Button>


### PR DESCRIPTION
## 📄 Paginação de Pedidos via URL

### 📝 Descrição
Implementação da lógica de paginação na listagem de pedidos.

A paginação foi construída utilizando o conceito de **URL State** (Estado na URL). Isso significa que a página atual não é guardada apenas na memória do React (`useState`), mas sim nos parâmetros da URL (`?page=2`). Isso permite que o usuário recarregue a página ou compartilhe o link mantendo exatamente a mesma visualização.

### ⚙️ Detalhes da Implementação

1.  **Gerenciamento de Estado (`useSearchParams`):**
    * Utilizamos o hook do React Router para ler e escrever o parâmetro `page` na URL.
    * `zod` é utilizado para garantir que o page index seja sempre um número válido (fallback para 0 se for inválido).

2.  **React Query (`queryKey`):**
    * A chave da query foi atualizada para `['orders', pageIndex]`.
    * **Efeito:** Sempre que a variável `pageIndex` muda (via URL), o React Query detecta a mudança na chave e dispara automaticamente uma nova requisição para a API (`refetch`).

3.  **UX da Paginação:**
    * Botões "Anterior", "Próximo", "Primeira" e "Última" agora possuem lógica de `disabled`.
    * Ex: Se estiver na página 0, o botão "Anterior" fica desabilitado visualmente e funcionalmente.

### 🧪 Como Testar
1.  Acesse a lista de pedidos.
2.  Clique no botão de **Próxima Página**.
    * *Verifique:* A URL deve mudar para `.../orders?page=1`.
    * *Verifique:* A tabela deve carregar novos dados.
3.  **Recarregue a página (F5).**
    * *Resultado esperado:* Você deve permanecer na página 1 (não voltar para a 0).
4.  Vá para a última página disponível.
    * *Verifique:* O botão "Próximo" e "Última" devem ficar desabilitados.

### 🔨 Checklist
- [x] API `getOrders` recebendo `pageIndex`.
- [x] Sincronização com `useSearchParams`.
- [x] `queryKey` atualizada com dependência da página.
- [x] Botões de navegação com estados de `disabled`.