### PR TITLE
feat(orders): implement table filters with url sync

### DIFF
--- a/src/api/get-orders.ts
+++ b/src/api/get-orders.ts
@@ -1,7 +1,11 @@
+import type { OrderStatus } from "@/components/ui/order-status";
 import { api } from "@/lib/axios";
 
 interface GetOrdersParams {
   pageIndex?: number | null;
+  orderId?: string | null;
+  customerName?: string | null;
+  status?: OrderStatus | "all" | null;
 }
 
 interface GetOrdersResponse {
@@ -19,10 +23,20 @@ interface GetOrdersResponse {
   };
 }
 
-export async function getOrders({ pageIndex = 0 }: GetOrdersParams) {
+/**
+ * Busca os pedidos do backend com base nos parâmetros fornecidos.
+ *
+ * @param {GetOrdersParams} params - Os parâmetros para filtrar os pedidos, sendo pageIndex, orderId, customerName e status.
+ * @returns {Promise<GetOrdersResponse>} - A resposta contendo os pedidos e os metadados de paginação.
+ */
+export async function getOrders({
+  pageIndex = 0,
+  ...params
+}: GetOrdersParams): Promise<GetOrdersResponse> {
   const response = await api.get<GetOrdersResponse>("/orders", {
     params: {
       pageIndex,
+      ...params,
     },
   });
 

--- a/src/components/ui/order-status.tsx
+++ b/src/components/ui/order-status.tsx
@@ -1,9 +1,12 @@
-type OrderStatus =
-  | "pending"
-  | "canceled"
-  | "processing"
-  | "delivering"
-  | "delivered";
+export const orderStatusArray = [
+  "pending",
+  "canceled",
+  "processing",
+  "delivering",
+  "delivered",
+] as const;
+
+export type OrderStatus = (typeof orderStatusArray)[number];
 
 interface OrderStatusProps {
   status: OrderStatus;

--- a/src/pages/app/orders/order-table-filters.tsx
+++ b/src/pages/app/orders/order-table-filters.tsx
@@ -1,7 +1,12 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import { Search, X } from "lucide-react";
+import { Controller, useForm } from "react-hook-form";
+import { useSearchParams } from "react-router";
+import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { orderStatusArray } from "@/components/ui/order-status";
 import {
   Select,
   SelectContent,
@@ -10,32 +15,136 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
+const orderFilterSchema = z.object({
+  orderId: z.string().optional(),
+  customerName: z.string().optional(),
+  status: z.enum([...orderStatusArray, "all"] as const).optional(),
+});
+
+type OrderFilterSchemaType = z.infer<typeof orderFilterSchema>;
+
 export function OrderTableFilters() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const orderId = searchParams.get("orderId") ?? "";
+  const customerName = searchParams.get("customerName") ?? "";
+  const status =
+    (searchParams.get("status") as OrderFilterSchemaType["status"]) || "all";
+
+  const { register, handleSubmit, control, reset } =
+    useForm<OrderFilterSchemaType>({
+      resolver: zodResolver(orderFilterSchema),
+      defaultValues: {
+        orderId,
+        customerName,
+        status,
+      },
+    });
+
+  /**
+   * Atualiza os parâmetros de busca na URL com base nos filtros aplicados.
+   * Se um filtro estiver vazio ou for "all", ele será removido dos parâmetros de busca.
+   *
+   * @param {OrderFilterSchemaType} filters - Os filtros aplicados pelo usuário.
+   */
+  function handleFilter({
+    orderId,
+    customerName,
+    status,
+  }: OrderFilterSchemaType) {
+    setSearchParams((prev) => {
+      if (orderId) {
+        prev.set("orderId", orderId);
+      } else {
+        prev.delete("orderId");
+      }
+
+      if (customerName) {
+        prev.set("customerName", customerName);
+      } else {
+        prev.delete("customerName");
+      }
+
+      if (status && status !== "all") {
+        prev.set("status", status);
+      } else {
+        prev.delete("status");
+      }
+
+      prev.set("page", "1");
+
+      return prev;
+    });
+  }
+
+  function handleClearFilters() {
+    setSearchParams((prev) => {
+      prev.delete("orderId");
+      prev.delete("customerName");
+      prev.delete("status");
+      prev.set("page", "1");
+
+      return prev;
+    });
+
+    reset();
+  }
+
   return (
-    <form className="flex items-center gap-2">
+    <form
+      onSubmit={handleSubmit(handleFilter)}
+      className="flex items-center gap-2"
+    >
       <span className="text-sm font-semibold">Filtros:</span>
-      <Input placeholder="ID do pedido" className="h-8 w-auto" />
-      <Input placeholder="Nome do cliente" className="h-8 w-[320px]" />
-      <Select defaultValue="all">
-        <SelectTrigger className="h-8 w-45">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="all">Todos status</SelectItem>
-          <SelectItem value="pending">Pendente</SelectItem>
-          <SelectItem value="canceled">Cancelado</SelectItem>
-          <SelectItem value="processing">Em preparo</SelectItem>
-          <SelectItem value="delivering">Em entrega</SelectItem>
-          <SelectItem value="delivered">Entregue</SelectItem>
-        </SelectContent>
-      </Select>
+      <Input
+        placeholder="ID do pedido"
+        className="h-8 w-auto"
+        {...register("orderId")}
+      />
+      <Input
+        placeholder="Nome do cliente"
+        className="h-8 w-[320px]"
+        {...register("customerName")}
+      />
+
+      <Controller
+        name="status"
+        control={control}
+        render={({ field: { onChange, value, ...field } }) => {
+          return (
+            <Select
+              onValueChange={(value) => onChange(value)}
+              defaultValue="all"
+              value={value}
+              {...field}
+            >
+              <SelectTrigger className="h-8 w-45">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos status</SelectItem>
+                <SelectItem value="pending">Pendente</SelectItem>
+                <SelectItem value="canceled">Cancelado</SelectItem>
+                <SelectItem value="processing">Em preparo</SelectItem>
+                <SelectItem value="delivering">Em entrega</SelectItem>
+                <SelectItem value="delivered">Entregue</SelectItem>
+              </SelectContent>
+            </Select>
+          );
+        }}
+      />
 
       <Button type="submit" variant="secondary" size="xs">
         <Search className="mr-2 h-4 w-4" />
         Filtrar resultados
       </Button>
 
-      <Button type="button" variant="outline" size="xs">
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        onClick={handleClearFilters}
+      >
         <X className="mr-2 h-4 w-4" />
         Remover filtros
       </Button>

--- a/src/pages/app/orders/orders.tsx
+++ b/src/pages/app/orders/orders.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 import { getOrders } from "@/api/get-orders";
 import { Pagination } from "@/components/pagination";
+import { OrderStatus, orderStatusArray } from "@/components/ui/order-status";
 import {
   Table,
   TableBody,
@@ -18,6 +19,14 @@ import { OrderTableRow } from "./order-table-row";
 
 export function Orders() {
   const [searchParams, setSearchParams] = useSearchParams();
+
+  const orderId = searchParams.get("orderId") ?? "";
+  const customerName = searchParams.get("customerName") ?? "";
+
+  const status = searchParams.get("status");
+  const isValidStatus =
+    status && orderStatusArray.includes(status as OrderStatus);
+  const finalStatus = isValidStatus ? (status as OrderStatus) : "all";
 
   /**
    * O backend espera um pageIndex baseado em zero, mas a interface do usuário é baseada em um pageIndex baseado em um.
@@ -37,8 +46,14 @@ export function Orders() {
     .parse(searchParams.get("page") ?? 0);
 
   const { data: result } = useQuery({
-    queryKey: ["orders", pageIndex],
-    queryFn: () => getOrders({ pageIndex }),
+    queryKey: ["orders", pageIndex, orderId, customerName, finalStatus],
+    queryFn: () =>
+      getOrders({
+        pageIndex,
+        orderId,
+        customerName,
+        status: finalStatus === "all" ? null : finalStatus,
+      }),
   });
 
   return (


### PR DESCRIPTION
## 🔍 Filtros de Pedidos e Refatoração de Tipos

### 📝 Descrição
Implementação do sistema de filtros na listagem de pedidos (ID, Nome e Status) com sincronização via URL.

Além da feature visual, esta PR inclui uma refatoração importante no sistema de tipagem dos **Status do Pedido**, visando maior segurança e facilidade de manutenção.

### 🧠 Deep Dive: Refatoração de Tipos (Single Source of Truth)
Para evitar a repetição de strings mágicas (`"pending" | "canceled" | ...`) espalhadas pelo código, adotamos o padrão de **Fonte Única da Verdade**.

**Como funciona:**
1.  **Imutabilidade (`as const`):**
    Criamos um array constante. O `as const` diz ao TypeScript que esse array não é uma lista genérica de strings, mas sim uma lista contendo *exatamente* aqueles literais.
    ```typescript
    export const orderStatusArray = ["pending", "canceled", ...] as const;
    ```

2.  **Derivação de Tipo:**
    Em vez de escrever o `type` manualmente, nós o derivamos do array. Se adicionarmos um novo status no array, o tipo atualiza automaticamente.
    ```typescript
    export type OrderStatus = (typeof orderStatusArray)[number];
    ```

3.  **Segurança em Tempo de Execução (Runtime):**
    Como a URL é "terra de ninguém" (o usuário pode digitar `?status=batata`), usamos o array para validar a entrada. O método `.includes()` garante que só aceitaremos valores que existem na nossa lista oficial.
    ```typescript
    const isValidStatus = status && orderStatusArray.includes(status as OrderStatus);
    const finalStatus = isValidStatus ? (status as OrderStatus) : "all";
    ```

4.  **Integração com Zod:**
    O Schema de validação também consome esse array, garantindo que o formulário, o banco de dados e a URL falem a mesma língua.
    ```typescript
    status: z.enum([...orderStatusArray, "all"] as const).optional()
    ```

### 🎮 Deep Dive: Controller vs Register (Radix UI)
Para o filtro de Status, utilizamos o componente `<Select />` do Radix UI (via Shadcn). Como o Radix não utiliza elementos `<select>` nativos do HTML, o método padrão `register` do React Hook Form não funciona (pois ele depende de `refs` e eventos nativos).

**A Solução:**
Utilizamos o componente `<Controller />`. Ele atua como uma ponte, permitindo mapear manualmente os eventos do RHF para o componente customizado:

```tsx
<Controller
  name="status"
  control={control}
  render={({ field: { name, onChange, value, disabled } }) => (
    <Select
      name={name}
      onValueChange={onChange} // Conecta o evento customizado do Radix ao RHF
      value={value}            // Força o componente a ser controlado pelo RHF
      disabled={disabled}
    >
      {/* ... */}
    </Select>
  )}
/>
```

### ⚙️ Detalhes da Implementação
* **Formulário:** `react-hook-form` + `zod`.
* **UI:** `Radix UI Select` controlado via `<Controller />`.
* **URL State:** `useSearchParams` para persistência dos filtros.
* **Limpeza:** Botão "Remover filtros" que reseta a URL.

### 🧪 Como Testar
1.  **Teste de Filtro:**
    * Selecione o status "Pendente" e clique em filtrar.
    * A URL deve mudar para `?status=pending`.
2.  **Teste de Segurança (O Refactor):**
    * Tente digitar manualmente na URL: `?status=invalido`.
    * Ao carregar a página, o filtro deve ignorar o valor inválido e assumir o padrão ("Todos" ou vazio), sem quebrar a aplicação.
3.  **Teste de Persistência:**
    * Aplique filtros e recarregue a página (F5). Os campos devem continuar preenchidos.

### 🔨 Checklist
- [x] Refatoração de `OrderStatus` (Array + Type).
- [x] Validação de parâmetros de URL (Type Narrowing).
- [x] Formulário de filtros conectado à URL.
- [x] Botão de limpar filtros.