### PR TITLE
feat(auth): implement automatic logout with flash message pattern

### DIFF
--- a/src/hooks/use-flash-message.ts
+++ b/src/hooks/use-flash-message.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+export function useFlashMessage() {
+  useEffect(() => {
+    const authError = localStorage.getItem("@pizzashop:auth-error");
+    if (authError) {
+      toast.warning("Sessão expirada", {
+        description: "Por favor, faça login novamente.",
+        id: "session-expired",
+      });
+
+      localStorage.removeItem("@pizzashop:auth-error");
+    }
+  }, []);
+}

--- a/src/pages/auth/sign-in.tsx
+++ b/src/pages/auth/sign-in.tsx
@@ -9,6 +9,7 @@ import { signIn } from "@/api/sign-in";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useFlashMessage } from "@/hooks/use-flash-message";
 
 const signInFormSchema = z.object({
   email: z.email(),
@@ -21,6 +22,7 @@ type signInFormSchemaType = z.infer<typeof signInFormSchema>;
 
 export function SignIn() {
   const [searchParams] = useSearchParams();
+  useFlashMessage();
 
   /**
    * defaultValues: Captura o e-mail da URL (caso o usuário tenha sido redirecionado após o cadastro)


### PR DESCRIPTION
## 🔒 Logout Automático e Flash Messages

### 📝 Descrição
Implementação de interceptadores globais no Axios para gerenciar a segurança e a experiência de desenvolvimento.

O destaque é o **Logout Automático**: ao detectar um erro `401 Unauthorized`, a aplicação redireciona o usuário para o login. Para garantir uma UX fluida mesmo após um *hard reload*, implementamos um sistema de **Flash Messages**.

### 🧠 Deep Dive: Flash Message Pattern
   - Para o logout, optamos por usar `window.location.href` ao invés de `useNavigate`.

   - **Motivo:** Segurança. O *hard reload* garante que todo o estado em memória (Context API, React Query Cache, Variáveis) seja limpo, evitando vazamento de dados de uma sessão para outra.

**O Desafio:**
   - Como a página é recarregada, perderíamos o disparo do Toast de "Sessão Expirada".

**A Solução (Flash Message):**
   - **No Interceptor (`api.ts`):** Antes de redirecionar, gravamos uma flag no `localStorage` (`@pizzashop:auth-error`).
   - **No Login (`useFlashMessage`):** Criamos um hook que verifica essa flag ao montar a tela de login. Se ela existir, dispara o toast e remove a flag imediatamente.

Isso garante que o usuário veja o feedback visual mesmo após a destruição total da árvore do React.

### ⚙️ Outras Implementações
* **Dev Tools (Interceptadores de Request):**
    * `enable-api-delay`: Simula latência de rede.
    * `enable-api-error`: Simula erros de API (Fault Injection) para testar tratamentos de erro.
* **Refatoração JSDoc:** Documentação técnica atualizada no `api.ts` explicando o fluxo de autenticação.

### 🧪 Como Testar

1.  **Logout Automático:**
    * Abra o DevTools > Application > Cookies e delete o cookie de sessão.
    * Tente navegar ou fazer uma ação.
    * *Resultado:* A página deve recarregar completamente e, na tela de login, deve aparecer o toast "Sessão expirada".
2.  **Persistência da Mensagem:**
    * Dê um refresh na tela de login após ver o toast.
    * *Resultado:* O toast **não** deve aparecer novamente (a flag deve ter sido consumida).

### 🔨 Checklist
- [x] Interceptor de Auth (401) com `window.location`.
- [x] Implementação do padrão Flash Message via `localStorage`.
- [x] Criação do hook `useFlashMessage`.
- [x] Documentação JSDoc atualizada.