### PR TITLE
feat(dashboard): implement loading skeletons for metric cards

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -8,7 +8,7 @@ export const api = axios.create({
 });
 
 /**
- * Irá interceptar todas as requisições e adicionar um delay de 1 segundo
+ * Irá interceptar todas as requisições e adicionar um delay aleatório entre 0 e 3 segundos, mas somente
  * caso a variável de ambiente VITE_ENABLE_API_DELAY esteja habilitada.
  *
  * Isso é útil para simular latência de rede durante o desenvolvimento.
@@ -18,7 +18,7 @@ export const api = axios.create({
 if (env.VITE_ENABLE_API_DELAY) {
   api.interceptors.request.use(async (config) => {
     await new Promise((resolve) => {
-      setTimeout(resolve, 2000);
+      setTimeout(resolve, Math.round(Math.random() * 3000));
     });
 
     return config;

--- a/src/pages/app/dashboard/day-orders-amount-card.tsx
+++ b/src/pages/app/dashboard/day-orders-amount-card.tsx
@@ -4,17 +4,15 @@ import { Utensils } from "lucide-react";
 import { getDayOrdersAmount } from "@/api/get-day-orders-amount";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
+import { MetricCardSkeleton } from "./metric-card-skeleton";
+
 export function DayOrdersAmountCard() {
   const { data: dayOrdersAmount } = useQuery({
     queryFn: getDayOrdersAmount,
     queryKey: ["metrics", "day-orders-amount"],
   });
 
-  if (!dayOrdersAmount) {
-    return null;
-  }
-
-  const amountFormatted = dayOrdersAmount.amount.toLocaleString("pt-BR");
+  const amountFormatted = dayOrdersAmount?.amount.toLocaleString("pt-BR");
 
   return (
     <Card>
@@ -24,7 +22,7 @@ export function DayOrdersAmountCard() {
       </CardHeader>
 
       <CardContent className="space-y-1 pt-0">
-        {dayOrdersAmount && (
+        {dayOrdersAmount ? (
           <>
             <span className="text-2xl font-bold tracking-tight">
               {amountFormatted}
@@ -47,6 +45,8 @@ export function DayOrdersAmountCard() {
               )}
             </p>
           </>
+        ) : (
+          <MetricCardSkeleton />
         )}
       </CardContent>
     </Card>

--- a/src/pages/app/dashboard/metric-card-skeleton.tsx
+++ b/src/pages/app/dashboard/metric-card-skeleton.tsx
@@ -1,0 +1,10 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function MetricCardSkeleton() {
+  return (
+    <>
+      <Skeleton className="h-7 w-36" />
+      <Skeleton className="mt-4 h-4 w-52" />
+    </>
+  );
+}

--- a/src/pages/app/dashboard/month-canceled-orders-amount-card.tsx
+++ b/src/pages/app/dashboard/month-canceled-orders-amount-card.tsx
@@ -4,18 +4,16 @@ import { DollarSign } from "lucide-react";
 import { getMonthCanceledOrdersAmount } from "@/api/get-month-canceled-orders-amount";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
+import { MetricCardSkeleton } from "./metric-card-skeleton";
+
 export function MonthCanceledOrdersAmountCard() {
   const { data: monthCanceledOrdersAmount } = useQuery({
     queryFn: getMonthCanceledOrdersAmount,
     queryKey: ["metrics", "month-canceled-orders-amount"],
   });
 
-  if (!monthCanceledOrdersAmount) {
-    return null;
-  }
-
   const amountFormatted =
-    monthCanceledOrdersAmount.amount.toLocaleString("pt-BR");
+    monthCanceledOrdersAmount?.amount.toLocaleString("pt-BR");
 
   return (
     <Card>
@@ -27,7 +25,7 @@ export function MonthCanceledOrdersAmountCard() {
       </CardHeader>
 
       <CardContent className="space-y-1 pt-0">
-        {monthCanceledOrdersAmount && (
+        {monthCanceledOrdersAmount ? (
           <>
             <span className="text-2xl font-bold tracking-tight">
               {amountFormatted}
@@ -50,6 +48,8 @@ export function MonthCanceledOrdersAmountCard() {
               )}
             </p>
           </>
+        ) : (
+          <MetricCardSkeleton />
         )}
       </CardContent>
     </Card>

--- a/src/pages/app/dashboard/month-orders-amount-card.tsx
+++ b/src/pages/app/dashboard/month-orders-amount-card.tsx
@@ -4,17 +4,15 @@ import { Utensils } from "lucide-react";
 import { getMonthOrdersAmount } from "@/api/get-month-orders-amount";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
+import { MetricCardSkeleton } from "./metric-card-skeleton";
+
 export function MonthOrdersAmountCard() {
   const { data: monthOrdersAmount } = useQuery({
     queryFn: getMonthOrdersAmount,
     queryKey: ["metrics", "month-orders-amount"],
   });
 
-  if (!monthOrdersAmount) {
-    return null;
-  }
-
-  const amountFormatted = monthOrdersAmount.amount.toLocaleString("pt-BR");
+  const amountFormatted = monthOrdersAmount?.amount.toLocaleString("pt-BR");
 
   return (
     <Card>
@@ -24,7 +22,7 @@ export function MonthOrdersAmountCard() {
       </CardHeader>
 
       <CardContent className="space-y-1 pt-0">
-        {monthOrdersAmount && (
+        {monthOrdersAmount ? (
           <>
             <span className="text-2xl font-bold tracking-tight">
               {amountFormatted}
@@ -47,6 +45,8 @@ export function MonthOrdersAmountCard() {
               )}
             </p>
           </>
+        ) : (
+          <MetricCardSkeleton />
         )}
       </CardContent>
     </Card>

--- a/src/pages/app/dashboard/month-revenue-card.tsx
+++ b/src/pages/app/dashboard/month-revenue-card.tsx
@@ -4,15 +4,15 @@ import { DollarSign } from "lucide-react";
 import { getMonthRenevue } from "@/api/get-month-revenue";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
+import { MetricCardSkeleton } from "./metric-card-skeleton";
+
 export function MonthRevenueCard() {
   const { data: getMonthRevenueAmount } = useQuery({
     queryFn: getMonthRenevue,
     queryKey: ["metrics", "month-revenue"],
   });
 
-  if (!getMonthRevenueAmount) return null;
-
-  const amountFormatted = getMonthRevenueAmount.receipt.toLocaleString(
+  const amountFormatted = getMonthRevenueAmount?.receipt.toLocaleString(
     "pt-BR",
     {
       style: "currency",
@@ -31,7 +31,7 @@ export function MonthRevenueCard() {
       </CardHeader>
 
       <CardContent className="space-y-1 pt-0">
-        {getMonthRevenueAmount && (
+        {getMonthRevenueAmount ? (
           <>
             <span className="text-2xl font-bold tracking-tight">
               {amountFormatted}
@@ -54,6 +54,8 @@ export function MonthRevenueCard() {
               )}
             </p>
           </>
+        ) : (
+          <MetricCardSkeleton />
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## 🔄 Loading States (Métricas)

### 📝 Descrição
Implementação de estados de carregamento (**Skeletons**) para os cards de métricas do Dashboard.

O objetivo é melhorar a percepção de performance. Ao invés de mostrar um espaço em branco ou "pulando" na tela (*Layout Shift*) quando os dados chegam, exibimos uma estrutura visual provisória.

### ⚙️ Detalhes da Implementação
1.  **Componente `MetricCardSkeleton`:**
    * Criado em `src/pages/app/dashboard/metric-card-skeleton.tsx`.
    * Utiliza o componente base `Skeleton` (Shadcn/UI) para simular o valor numérico e o texto de rodapé.
    
2.  **Estratégia de Renderização:**
    * Mantivemos o `CardHeader` (Título e Ícone) sempre visível.
    * O Skeleton é aplicado apenas dentro do `CardContent`, substituindo o valor e a porcentagem enquanto `data` for `undefined`.

### 🧠 Decisões de Design
Optamos por mostrar o esqueleto apenas do **conteúdo** e não do card inteiro.

**Motivo:** Isso ancora a interface. O usuário já vê "Receita total" e o ícone de cifrão imediatamente, diminuindo a ansiedade cognitiva enquanto aguarda apenas o número carregar.

### 🧪 Como Testar
1.  Acesse o Dashboard.
2.  Recarregue a página (F5).
3.  Observe os retângulos cinza pulsantes nos cards antes dos números aparecerem.
4.  (Opcional) Ative o `delay` artificial no interceptor do Axios para ver a animação por mais tempo.

### 🔨 Checklist
- [x] Criação do componente de Skeleton.
- [x] Aplicação no Card de Receita.
- [x] Aplicação no Card de Pedidos (Dia/Mês).
- [x] Aplicação no Card de Cancelamentos.