### PR TITLE
feat(orders): implement order details skeleton loading state

### DIFF
--- a/src/api/get-order-details.ts
+++ b/src/api/get-order-details.ts
@@ -1,13 +1,13 @@
-import type { OrderStatus } from "@/components/ui/order-status";
+import type { OrderStatusType } from "@/components/ui/order-status";
 import { api } from "@/lib/axios";
 
-interface CancelOrderParams {
+interface GetOrderParams {
   orderId: string;
 }
 
-interface CancelOrderResponse {
+interface GetOrderResponse {
   id: string;
-  status: OrderStatus;
+  status: OrderStatusType;
   createdAt: string;
   totalInCents: number;
   customer: {
@@ -25,8 +25,8 @@ interface CancelOrderResponse {
   }[];
 }
 
-export async function cancelOrder({ orderId }: CancelOrderParams) {
-  const response = await api.get<CancelOrderResponse>(`/orders/${orderId}`);
+export async function getOrderDetails({ orderId }: GetOrderParams) {
+  const response = await api.get<GetOrderResponse>(`/orders/${orderId}`);
 
   return response.data;
 }

--- a/src/pages/app/orders/order-details-skeleton.tsx
+++ b/src/pages/app/orders/order-details-skeleton.tsx
@@ -1,0 +1,97 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+export function OrderDetailsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell className="text-muted-foreground">Status</TableCell>
+            <TableCell className="flex justify-end">
+              <Skeleton className="h-5 w-20" />
+            </TableCell>
+          </TableRow>
+
+          <TableRow>
+            <TableCell className="text-muted-foreground">Cliente</TableCell>
+            <TableCell className="flex justify-end">
+              <Skeleton className="h-5 w-41" />
+            </TableCell>
+          </TableRow>
+
+          <TableRow>
+            <TableCell className="text-muted-foreground">Telefone</TableCell>
+            <TableCell className="flex justify-end">
+              <Skeleton className="h-5 w-35" />
+            </TableCell>
+          </TableRow>
+
+          <TableRow>
+            <TableCell className="text-muted-foreground">Email</TableCell>
+            <TableCell className="flex justify-end">
+              <Skeleton className="h-5 w-50" />
+            </TableCell>
+          </TableRow>
+
+          <TableRow>
+            <TableCell className="text-muted-foreground">
+              Realizado há
+            </TableCell>
+            <TableCell className="flex justify-end">
+              <Skeleton className="h-5 w-37" />
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Produto</TableHead>
+            <TableHead className="text-right">Quantidade</TableHead>
+            <TableHead className="text-right">Preço</TableHead>
+            <TableHead className="text-right">Subtotal</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {Array.from({ length: 2 }).map((_, index) => {
+            return (
+              <TableRow key={index}>
+                <TableCell>
+                  {" "}
+                  <Skeleton className="h-5 w-35" />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Skeleton className="ml-auto h-5 w-3" />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Skeleton className="ml-auto h-5 w-12" />
+                </TableCell>
+                <TableCell className="text-right">
+                  <Skeleton className="ml-auto h-5 w-12" />
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={3}>Total do pedido</TableCell>
+            <TableCell className="text-right font-medium">
+              <Skeleton className="h-5 w-20" />
+            </TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </div>
+  );
+}

--- a/src/pages/app/orders/order-details.tsx
+++ b/src/pages/app/orders/order-details.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns/formatDistanceToNow";
 import { ptBR } from "date-fns/locale/pt-BR";
 
-import { cancelOrder } from "@/api/get-order-details";
+import { getOrderDetails } from "@/api/get-order-details";
 import {
   DialogContent,
   DialogDescription,
@@ -20,6 +20,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 
+import { OrderDetailsSkeleton } from "./order-details-skeleton";
+
 interface OrderDetailsProps {
   orderId: string;
   open: boolean;
@@ -32,7 +34,7 @@ export function OrderDetails({ orderId, open }: OrderDetailsProps) {
    */
   const { data: orderDetails } = useQuery({
     queryKey: ["order", orderId],
-    queryFn: () => cancelOrder({ orderId }),
+    queryFn: () => getOrderDetails({ orderId }),
     enabled: open,
   });
 
@@ -51,10 +53,6 @@ export function OrderDetails({ orderId, open }: OrderDetailsProps) {
       minimumFractionDigits: 2,
     });
 
-  if (!orderDetails) {
-    return null;
-  }
-
   return (
     <div>
       <DialogContent>
@@ -63,7 +61,7 @@ export function OrderDetails({ orderId, open }: OrderDetailsProps) {
           <DialogDescription>Detalhes do pedido</DialogDescription>
         </DialogHeader>
 
-        {orderDetails && (
+        {orderDetails ? (
           <div className="space-y-6">
             <Table>
               <TableBody>
@@ -172,6 +170,8 @@ export function OrderDetails({ orderId, open }: OrderDetailsProps) {
               </TableFooter>
             </Table>
           </div>
+        ) : (
+          <OrderDetailsSkeleton />
         )}
       </DialogContent>
     </div>


### PR DESCRIPTION
## 💀 Loading de Detalhes do Pedido (Skeleton)

### 📝 Descrição
Implementação do estado de carregamento para o Modal de Detalhes do Pedido.
Criamos um **Skeleton Screen** complexo que imita a estrutura de tabelas aninhadas (Dados do Cliente + Lista de Produtos) para evitar mudanças bruscas de layout.

### ⚙️ Detalhes da Implementação
1.  **Correção de UX (Modal Delay):**
    * Anteriormente, o componente retornava `null` se não houvesse dados (`if (!data) return null`), o que impedia a abertura imediata do Modal.
    * **Fix:** Agora renderizamos o `<DialogContent>` incondicionalmente e alternamos entre o conteúdo real e o `<OrderDetailsSkeleton />` internamente.

2.  **Componente `OrderDetailsSkeleton`:**
    * Reproduz fielmente a estrutura de duas tabelas (Info do Pedido e Itens).
    * Utiliza skeletons alinhados à direita para valores monetários e numéricos.

3.  **Correção de Bug:**
    * Ajustamos a função de busca no `useQuery` que estava incorretamente apontando para `cancelOrder`. Agora aponta para `getOrderDetails`.

### 🧪 Como Testar
1.  Na listagem de pedidos, clique na lupa (🔍) de qualquer pedido.
2.  O modal deve abrir **instantaneamente**.
3.  Você deve ver barras cinzas pulsantes (Skeleton) por alguns instantes.
4.  Os dados reais devem substituir o esqueleto sem "pulos" de layout.

### 🔨 Checklist
- [x] Componente `OrderDetailsSkeleton`.
- [x] Correção do delay de abertura do modal.
- [x] Correção da função de fetch.